### PR TITLE
Push to production i.e. quay.io

### DIFF
--- a/.github/diffversions.sh
+++ b/.github/diffversions.sh
@@ -4,19 +4,19 @@
 # It compares the versions of the packages in the old and new repositories and
 # generates a message with the differences.
 # It expects the following files to be present in the current directory:
-# - versions_framework.old.yaml -> from the old repository framework image
-# - versions_framework.new.yaml -> from the new repository framework image
+# - versions_generic.old.yaml -> from the old repository framework image
+# - versions_generic.new.yaml -> from the new repository framework image
 # - versions_fips.old.yaml -> from the old repository fips image
 # - versions_fips.new.yaml -> from the new repository fips image
 
-stat versions_framework.old.yaml > /dev/null 2>&1
+stat versions_generic.old.yaml > /dev/null 2>&1
 if [[ $? != 0 ]]; then
-  echo "versions_framework.old.yaml not found"
+  echo "versions_generic.old.yaml not found"
   exit 1
 fi
-stat versions_framework.new.yaml > /dev/null 2>&1
+stat versions_generic.new.yaml > /dev/null 2>&1
 if [[ $? != 0 ]]; then
-  echo "versions_framework.new.yaml not found"
+  echo "versions_generic.new.yaml not found"
   exit 1
 fi
 stat versions_fips.old.yaml > /dev/null 2>&1
@@ -31,8 +31,8 @@ if [[ $? != 0 ]]; then
 fi
 
 # Merge and sort versions files
-yq -P '.|=sort_by(.name, .category)|.[]|[{"name": .name, "category": .category, "version": .version}]' versions_framework.old.yaml versions_fips.old.yaml > merged.old.yaml
-yq -P '.|=sort_by(.name, .category)|.[]|[{"name": .name, "category": .category, "version": .version}]' versions_framework.new.yaml versions_fips.new.yaml > merged.new.yaml
+yq -P '.|=sort_by(.name, .category)|.[]|[{"name": .name, "category": .category, "version": .version}]' versions_generic.old.yaml versions_fips.old.yaml > merged.old.yaml
+yq -P '.|=sort_by(.name, .category)|.[]|[{"name": .name, "category": .category, "version": .version}]' versions_generic.new.yaml versions_fips.new.yaml > merged.new.yaml
 # Remove yaml separator
 sed -i 's|---||g' merged.old.yaml
 sed -i 's|---||g' merged.new.yaml

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,111 +10,33 @@ jobs:
       - uses: actions/checkout@v4
       - name: Extract versions
         run: |
-          docker run --name framework ttl.sh/framework:main true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml versions_framework.old.yaml
-          docker rm framework
-          docker run --name framework_fips ttl.sh/framework_fips:main true || true
-          docker cp framework_fips:/framework/etc/kairos/versions.yaml versions_fips.old.yaml
-          docker rm framework_fips
+          docker run --name generic quay.io/kairos/framework:main_generic true || true
+          docker cp generic:/framework/etc/kairos/versions.yaml versions_generic.old.yaml
+          docker rm generic
+          docker run --name fips quay.io/kairos/framework:main_fips true || true
+          docker cp fips:/framework/etc/kairos/versions.yaml versions_fips.old.yaml
+          docker rm fips
       - uses: actions/upload-artifact@v3
         with:
           name: old_versions.zip
           path: |
-            versions_framework.old.yaml
+            versions_generic.old.yaml
             versions_fips.old.yaml
-  build-framework:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ttl.sh/framework
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push framework
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: framework
-      - name: Extract versions
-        run: |
-          docker run --name framework ${{ steps.meta.outputs.tags }} true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml versions_framework.new.yaml
-          .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
-          docker rm framework
-      - uses: actions/upload-artifact@v3
-        with:
-          name: versions.zip
-          path: |
-            versions_framework.new.yaml
-          if-no-files-found: error
-  build-framework-fips:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ttl.sh/framework_fips
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push framework
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: framework_fips
-      - name: Extract versions
-        run: |
-          docker run --name framework ${{ steps.meta.outputs.tags }} true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml versions_fips.new.yaml
-          .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
-          docker rm framework
-      - uses: actions/upload-artifact@v3
-        with:
-          name: versions_fips.zip
-          path: |
-            versions_fips.new.yaml
-          if-no-files-found: error
+  build-generic:
+    uses: ./.github/workflows/reusable-build.yaml
+    secrets: inherit 
+    with:
+      security_profile: generic
+  build-fips:
+    uses: ./.github/workflows/reusable-build.yaml
+    secrets: inherit
+    with:
+      security_profile: fips
   comment-pr:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    needs: [build-framework, build-framework-fips, get-old-versions]
+    needs: [build-generic, build-fips, get-old-versions]
     steps:
       - uses: actions/checkout@v4
       - name: Download versions

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,81 +5,16 @@ on:
     tags:
       - v*
     branches:
-      - master
       - main
 
 jobs:
   build-framework:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ttl.sh/framework
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push framework
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: framework
-      - name: Extract versions
-        run: |
-          docker run --name framework ${{ steps.meta.outputs.tags }} true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml .
-          .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
-          docker rm framework
+    uses: ./.github/workflows/reusable-build.yaml
+    secrets: inherit 
+    with:
+      security_profile: generic
   build-framework-fips:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@master
-        with:
-          platforms: all
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            ttl.sh/framework_fips
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Build and push framework
-        uses: docker/build-push-action@v5
-        with:
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          target: framework_fips
-      - name: Extract versions
-        run: |
-          docker run --name framework ${{ steps.meta.outputs.tags }} true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml .
-          .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
-          docker rm framework
+    uses: ./.github/workflows/reusable-build.yaml
+    secrets: inherit 
+    with:
+      security_profile: fips

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -1,0 +1,72 @@
+name: Reusable Build Framework Image
+
+on:
+  workflow_call:
+    inputs:
+      security_profile:
+        required: true
+        type: string
+
+jobs:
+  build-framework:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Event PR
+        if: ${{ github.event_name == 'pull_request' }}
+        run: |
+            echo "EVENT_TYPE=pr" >> $GITHUB_ENV
+            echo "REPOSITORY=ttl.sh/framework_${{ inputs.security_profile }}" >> $GITHUB_ENV
+      - name: Event Branch
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+            echo "EVENT_TYPE=branch" >> $GITHUB_ENV
+            echo "REPOSITORY=quay.io/kairos/framework:${{  github.ref_name }}_${{ inputs.security_profile }}" >> $GITHUB_ENV
+      - name: Login to Quay Registry
+        if: ${{ github.event_name == 'push' }}
+        run: echo ${{ secrets.QUAY_PASSWORD }} | docker login -u ${{ secrets.QUAY_USERNAME }} --password-stdin quay.io
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ env.REPOSITORY }}
+          tags: |
+            type=schedule
+            type=ref,event=${{ env.EVENT_TYPE }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+      - name: print labels and tags
+        run: |
+          echo "lables: ${{ steps.meta.outputs.labels }}"
+          echo "tags: ${{ steps.meta.outputs.tags }}"
+      - name: Build and push framework
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: final
+          build-args: |
+            SECURITY_PROFILE=${{ inputs.security_profile }}
+      - name: Extract versions
+        run: |
+          docker run --name framework ${{ steps.meta.outputs.tags }} true || true
+          docker cp framework:/framework/etc/kairos/versions.yaml ./versions_${{ inputs.security_profile }}.new.yaml
+          .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
+          docker rm framework
+      - uses: actions/upload-artifact@v3
+        with:
+          name: versions_${{ inputs.security_profile }}.zip
+          path: |
+            versions_${{ inputs.security_profile }}.new.yaml
+          if-no-files-found: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG SECURITY_PROFILE=generic
 FROM quay.io/luet/base:0.35.0 AS luet
 
 # Common packages for all images
-FROM alpine AS generic
+FROM alpine AS base
 ENV LUET_NOLOCK=true
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 COPY repositories.yaml /repositories.yaml
@@ -13,32 +13,26 @@ RUN luet install -y --config repositories.yaml --system-target /framework \
   dracut/kairos-sysext \
   system/suc-upgrade \
   system/grub2-efi \
-  system/kcrypt \
-  system/kcrypt-challenger \
-  system/immucore \
-  system/kairos-agent \
-  system/kcrypt \
   static/grub-config \
   static/kairos-overlay-files \
   initrd/alpine
 
+FROM base AS generic
+RUN luet install -y --config repositories.yaml --system-target /framework \
+    system/kcrypt \
+    system/kcrypt-challenger \
+    system/immucore \
+    system/kairos-agent
 
-RUN mkdir -p /framework/etc/kairos/
-RUN luet database --system-target /framework get-all-installed --output /framework/etc/kairos/versions.yaml
-
-# luet cleanup
-RUN luet cleanup --system-target /framework
-RUN rm -rf /framework/var/luet
-RUN rm -rf /framework/var/cache
-
-# on fips, overwrite the binaries with its fips version
-FROM generic AS fips
+FROM base AS fips
 RUN luet install -y --config repositories.yaml --system-target /framework \
     fips/kcrypt \
     fips/kcrypt-challenger \
     fips/immucore \
     fips/kairos-agent
 
+# Final images
+FROM ${SECURITY_PROFILE} AS post
 RUN mkdir -p /framework/etc/kairos/
 RUN luet database --system-target /framework get-all-installed --output /framework/etc/kairos/versions.yaml
 
@@ -47,7 +41,5 @@ RUN luet cleanup --system-target /framework
 RUN rm -rf /framework/var/luet
 RUN rm -rf /framework/var/cache
 
-
-# Final images
-FROM ${SECURITY_PROFILE} AS final
-COPY /framework /framework
+FROM scratch AS final
+COPY --from=post /framework /framework

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM quay.io/luet/base:0.35.0 as luet
+ARG SECURITY_PROFILE=generic
+
+FROM quay.io/luet/base:0.35.0 AS luet
 
 # Common packages for all images
-FROM alpine as framework_base
+FROM alpine AS generic
 ENV LUET_NOLOCK=true
 COPY --from=luet /usr/bin/luet /usr/bin/luet
 COPY repositories.yaml /repositories.yaml
@@ -30,7 +32,7 @@ RUN rm -rf /framework/var/luet
 RUN rm -rf /framework/var/cache
 
 # on fips, overwrite the binaries with its fips version
-FROM framework_base as framework_base_fips
+FROM generic AS fips
 RUN luet install -y --config repositories.yaml --system-target /framework \
     fips/kcrypt \
     fips/kcrypt-challenger \
@@ -47,8 +49,5 @@ RUN rm -rf /framework/var/cache
 
 
 # Final images
-FROM scratch as framework
-COPY --from=framework_base /framework /framework
-
-FROM scratch as framework_fips
-COPY --from=framework_base_fips /framework /framework
+FROM ${SECURITY_PROFILE} AS final
+COPY /framework /framework


### PR DESCRIPTION
In this PR

- Extract build logic into reusable job
- Push to quay for master and tags (but keep pushing to ttl.sh for PRs)
- Adopt existing framework image tags but now uses main branch i.e. main_generic and main_fips
- Reduce duplication in Dockerfile

:warning: 

1. PRs will not be green until the new images have been published in quay from main
2. still needs to be consumed on the kairos repo

relates to kairos-io/kairos#1975