### PR TITLE
Keep final framework files at root

### DIFF
--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Extract versions
         run: |
           docker run --name framework ${{ steps.meta.outputs.tags }} true || true
-          docker cp framework:/framework/etc/kairos/versions.yaml ./versions_${{ inputs.security_profile }}.new.yaml
+          docker cp framework:/etc/kairos/versions.yaml ./versions_${{ inputs.security_profile }}.new.yaml
           .github/yaml2md.sh >> $GITHUB_STEP_SUMMARY
           docker rm framework
       - uses: actions/upload-artifact@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,4 +42,4 @@ RUN rm -rf /framework/var/luet
 RUN rm -rf /framework/var/cache
 
 FROM scratch AS final
-COPY --from=post /framework /framework
+COPY --from=post /framework /


### PR DESCRIPTION
This is how the previous images where built and I think it's probably better to keep it that way since there's nothing else in the image