### PR TITLE
Drop efi package from framework

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN luet install -y --config repositories.yaml --system-target /framework \
   dracut/kairos-network \
   dracut/kairos-sysext \
   system/suc-upgrade \
-  system/grub2-efi \
   static/grub-config \
   static/kairos-overlay-files \
   initrd/alpine


### PR DESCRIPTION
The idea is that for the installation, the source rootfs already contain the needed efi files as they were installed from their own sources.

For bulding the iso the packages are still shipped as part of the osbulder, but the framework should not need it anymore