### PR TITLE
Scan images and upload results before pushing them

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,4 +61,3 @@ jobs:
         with:
             comment_tag: bot-comment
             filePath: pr-message
-

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -82,7 +82,7 @@ jobs:
           image-ref: ${{ steps.meta.outputs.tags }}
           exit-code: '1'
           format: 'github'
-          severity: 'critical'
+          severity: 'CRITICAL'
       - name: Run Grype vulnerability scanner on PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: anchore/scan-action@v3

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -62,7 +62,46 @@ jobs:
           echo "lables: ${{ steps.meta.outputs.labels }}"
           echo "tags: ${{ steps.meta.outputs.tags }}"
           echo "version: ${{ steps.meta.outputs.version }}"
-      - name: Build and push framework
+      - name: Build framework
+        uses: docker/build-push-action@v6
+        with:
+          local: true
+          sbom: false
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          target: final
+          build-args: |
+            SECURITY_PROFILE=${{ inputs.security_profile }}
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: ${{ steps.meta.outputs.tags }}
+          exit-code: '1'
+          severity: 'CRITICAL'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+      - name: Run Grype vulnerability scanner
+        id: grype
+        uses: anchore/scan-action@v3
+        with:
+          image: ${{ steps.meta.outputs.tags }}
+          fail-build: true
+          severity-cutoff: critical
+          output-format: 'sarif'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        if: ${{ github.event_name == 'push' }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+      - name: Upload Grype scan results to GitHub Security tab
+        if: ${{ github.event_name == 'push' }}
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+      - name: Push framework
         uses: docker/build-push-action@v6
         with:
           sbom: false

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Build framework
         uses: docker/build-push-action@v6
         with:
-          local: true
+          load: true
           sbom: false
           platforms: linux/amd64,linux/arm64
           push: false

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -81,9 +81,8 @@ jobs:
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
           exit-code: '1'
-          format: 'github'
+          format: 'table'
           severity: 'CRITICAL'
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Grype vulnerability scanner on PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: anchore/scan-action@v3

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -75,21 +75,37 @@ jobs:
           target: final
           build-args: |
             SECURITY_PROFILE=${{ inputs.security_profile }}
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy vulnerability scanner on PR
+        if: ${{ github.event_name == 'pull_request' }}
         uses: aquasecurity/trivy-action@0.20.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
-          #exit-code: '1'
+          exit-code: '1'
+          format: 'github'
+          severity: 'critical'
+      - name: Run Grype vulnerability scanner on PR
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: anchore/scan-action@v3
+        with:
+          image: ${{ steps.meta.outputs.tags }}
+          severity-cutoff: critical
+          output-format: 'table'
+          fail-build: true
+      - name: Run Trivy vulnerability scanner on push
+        if: ${{ github.event_name == 'push' }}
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: ${{ steps.meta.outputs.tags }}
           format: 'sarif'
           output: 'trivy-results.sarif'
-      - name: Run Grype vulnerability scanner
+      - name: Run Grype vulnerability scanner on push
         id: grype
         uses: anchore/scan-action@v3
         with:
           image: ${{ steps.meta.outputs.tags }}
-          #fail-build: true
           severity-cutoff: critical
           output-format: 'sarif'
+          fail-build: false
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -83,6 +83,7 @@ jobs:
           exit-code: '1'
           format: 'github'
           severity: 'CRITICAL'
+          github-pat: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Grype vulnerability scanner on PR
         if: ${{ github.event_name == 'pull_request' }}
         uses: anchore/scan-action@v3
@@ -99,6 +100,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Run Grype vulnerability scanner on push
+        if: ${{ github.event_name == 'push' }}
         id: grype
         uses: anchore/scan-action@v3
         with:

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -79,8 +79,7 @@ jobs:
         uses: aquasecurity/trivy-action@0.20.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
-          exit-code: '1'
-          severity: 'CRITICAL'
+          #exit-code: '1'
           format: 'sarif'
           output: 'trivy-results.sarif'
       - name: Run Grype vulnerability scanner
@@ -88,7 +87,7 @@ jobs:
         uses: anchore/scan-action@v3
         with:
           image: ${{ steps.meta.outputs.tags }}
-          fail-build: true
+          #fail-build: true
           severity-cutoff: critical
           output-format: 'sarif'
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -62,12 +62,13 @@ jobs:
           echo "lables: ${{ steps.meta.outputs.labels }}"
           echo "tags: ${{ steps.meta.outputs.tags }}"
           echo "version: ${{ steps.meta.outputs.version }}"
+      # Build amd64 image to scan for vulnerabilities
       - name: Build framework
         uses: docker/build-push-action@v6
         with:
           load: true
           sbom: false
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -90,7 +91,6 @@ jobs:
           fail-build: true
           severity-cutoff: critical
           output-format: 'sarif'
-
       - name: Upload Trivy scan results to GitHub Security tab
         if: ${{ github.event_name == 'push' }}
         uses: github/codeql-action/upload-sarif@v2
@@ -101,7 +101,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{ steps.grype.outputs.sarif }}
-      - name: Push framework
+      - name: Build and push framework
         uses: docker/build-push-action@v6
         with:
           sbom: false


### PR DESCRIPTION
This adds trivy and grype scanning to PRs, failing the job when they dont pass.

It also pushes the sarif results on merge to master