### PR TITLE
Downgrade kairos-agent to 2.15.5

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -10,10 +10,10 @@ repositories:
     urls:
       - "quay.io/kairos/packages"
     # renovate: datasource=docker depName=quay.io/kairos/packages
-    reference: 202412111624-git810b97b8-repository.yaml
+    reference: 202412130756-gita1c730b1-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
     # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
-    reference: 202412111706-git810b97b8-repository.yaml
+    reference: 202412130807-gita1c730b1-repository.yaml


### PR DESCRIPTION
because to get a patch release out:

https://github.com/kairos-io/kairos/issues/3043

(we don't want too many changes in this release)