### PR TITLE
Bump repos

### DIFF
--- a/repositories.yaml
+++ b/repositories.yaml
@@ -10,10 +10,10 @@ repositories:
     urls:
       - "quay.io/kairos/packages"
     # renovate: datasource=docker depName=quay.io/kairos/packages
-    reference: 202501310814-gitdc432392-repository.yaml
+    reference: 202502140823-git1b0beb32-repository.yaml
   - !!merge <<: *kairos
     arch: arm64
     urls:
       - "quay.io/kairos/packages-arm64"
     # renovate: datasource=docker depName=quay.io/kairos/packages-arm64
-    reference: 202501310758-gitdc432392-repository.yaml
+    reference: 202502140947-git1b0beb32-repository.yaml


### PR DESCRIPTION
to bump kairos-agent so we get the fix for the copying of sysext: https://github.com/kairos-io/kairos-agent/pull/660/files